### PR TITLE
Remove install requirement

### DIFF
--- a/python_ci.yml
+++ b/python_ci.yml
@@ -1,46 +1,26 @@
 version: 2.1
 
 jobs:
-    install_py3:
-        docker:
-            - image: svalinn/pymoab-py3-18.04
-        steps:
-            - checkout #pull repo in the docker container
-            - run: pip install -e . --user
     run_test_py3:
         docker:
             - image: svalinn/pymoab-py3-18.04
         steps:
             - checkout #pull repo in the docker container
-            - run: pip install -e . --user
             - run:
                 working_drectory: #/directory
-            command: pytest
+            command: python -m pytest
 
-    install_py2:
-        docker:
-            - image: svalinn/pymoab-py2-18.04
-        steps:
-            - checkout #pull repo in the docker container
-            - run: pip install -e . --user
     run_test_py2:
         docker:
             - image: svalinn/pymoab-py2-18.04
         steps:
             - checkout #pull repo in the docker container
-            - run: pip install -e . --user
             - run:
                 working_drectory: #/directory
-            command: pytest
+            command: python -m pytest
 
 workflows:
     my_workflows:
         jobs:
-            - install_py3
             - run_test_py3
-                requires:
-                   - install_py3
-            - install_py2
             - run_test_py2
-                requires:
-                    - install_py2


### PR DESCRIPTION
With the right structure, it is not necessary to install the project before
running tests.  It is probably(?) not good practice to have to do this.

Instead, if the tests are in a directory 'tests' and they properly include
modules & submodules in a directory <module_name> then running
`python -m pytest` from the repo root directory should work.